### PR TITLE
update domain to narmi.com and remove outdated CI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # fedwire
-[![Build Status](https://travis-ci.org/narmitech/fedwire.svg?branch=master)](https://travis-ci.org/narmitech/fedwire)
 
 A python package that implements an interface to write files for the [Fedwire Funds Service](https://www.frbservices.org/financial-services/wires/index.html), [a real-time gross settlement funds transfer system operated by the United States Federal Reserve Banks](https://en.wikipedia.org/wiki/Fedwire). These [compatible files](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.445.7645&rep=rep1&type=pdf) include routing instructions that, once received and processed, will debit the funds from the sending bank's reserve account at their Federal Reserve bank and credit the receiving bank's account. Wire transfers sent via Fedwire are completed in the same day, while some are completed instantly.
 

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setuptools.setup(
         version=version,
         description='{0}\n\n{1}'.format(description, history),
         author='Narmi',
-        author_email='support@naritech.com',
-        url='https://github.com/narmitech/fedwire-python',
+        author_email='support@narmi.com',
+        url='https://github.com/narmi/fedwire',
         install_requires=[],
         extras_require={
             'dev': [


### PR DESCRIPTION
The narmitech.com domain has been deprecated, so this replaces it with narmi.com! 